### PR TITLE
Enforcer (USA miniaod)

### DIFF
--- a/config/dealer_config.json
+++ b/config/dealer_config.json
@@ -36,7 +36,8 @@
         "priority": 4,
         "module": "EnforcerHandler",
         "config": {
-           "max_dataset_size": 50.0
+           "max_dataset_size": 50.0,
+	   "policy": "$(DYNAMO_BASE)/policies/common/enforcer_rules.json"
           }
         }
       },

--- a/config/dealer_config.json
+++ b/config/dealer_config.json
@@ -32,6 +32,14 @@
       }
     },
     "plugins": {
+      "enforcer": {
+        "priority": 4,
+        "module": "EnforcerHandler",
+        "config": {
+           "max_dataset_size": 50.0
+          }
+        }
+      },
       "popularity": {
         "priority": 3,
         "module": "PopularityHandler",

--- a/config/detox_config.json
+++ b/config/detox_config.json
@@ -55,6 +55,9 @@
       },
       "ProtectedSiteTagger": {
         "sites": ["T1_IT_CNAF_MSS"]
+      },
+      "EnforcedProtectionTagger": {
+        "policy": "$(DYNAMO_BASE)/policies/common/enforcer_rules.json"
       }
     }
   },

--- a/lib/dealer/plugins/__init__.py
+++ b/lib/dealer/plugins/__init__.py
@@ -7,7 +7,7 @@ from undertaker import Undertaker
 __all__ = [
     'PopularityHandler',
 #    'DirectRequestsHandler',
-    'EnforcerHandle',
+    'EnforcerHandler',
     'BalancingHandler',
     'Undertaker'
 ]

--- a/lib/dealer/plugins/__init__.py
+++ b/lib/dealer/plugins/__init__.py
@@ -1,11 +1,13 @@
 from popularity import PopularityHandler
 #from direct import DirectRequestsHandler
 from balancer import BalancingHandler
+from enforcer import EnforcerHandler
 from undertaker import Undertaker
 
 __all__ = [
     'PopularityHandler',
 #    'DirectRequestsHandler',
+    'EnforcerHandle',
     'BalancingHandler',
     'Undertaker'
 ]

--- a/lib/dealer/plugins/enforcer.py
+++ b/lib/dealer/plugins/enforcer.py
@@ -18,7 +18,7 @@ class EnforcerHandler(BaseHandler):
         self.policy = Configuration(config.policy)
         self.max_dataset_size = config.max_dataset_size * 1.e+12
 
-    def get_requests(self, inventory, policy): # override
+    def get_requests(self, inventory): # override
         requests = []
 
         for rule in self.policy.rules:
@@ -73,5 +73,5 @@ class EnforcerHandler(BaseHandler):
 
                     requests.append((dataset,random_site))
 
-    return requests
+        return requests
 

--- a/lib/dealer/plugins/enforcer.py
+++ b/lib/dealer/plugins/enforcer.py
@@ -1,0 +1,74 @@
+import logging
+import re
+import random
+
+from base import BaseHandler
+
+LOG = logging.getLogger(__name__)
+
+class EnforcerHandler(BaseHandler):
+    """
+    Request replication of datasets using custom rules and destinations.
+    """
+
+    def __init__(self, config):
+        BaseHandler.__init__(self, 'Enforcer')
+
+        self.max_dataset_size = config.max_dataset_size * 1.e+12
+
+    def get_requests(self, inventory, policy): # override
+        requests = []
+
+        for rule in config.rules:
+            # split up sites into considered ones and others                                                                                                                                               
+            sites_considered = []
+            sites_others = []
+
+            for site in inventory.sites.values():
+                quota = site.partitions[partition].quota
+
+                LOG.debug('Site %s quota %f TB', site.name, quota * 1.e-12)
+
+                if quota <= 0:
+                # if the site has 0 or infinite quota, don't consider in enforcer
+                    continue
+
+                site_considered = False
+                for sitename in rule['sites']:
+                    pattern = re.compile(sitename.replace("*","[^\s]*"))
+                    if pattern.match(site.name):
+                        site_considered = True
+                if site_considered:
+                    sites_considered.append(site)
+                else:
+                    sites_others.append(site)
+
+            # How many copies already present at considered/other sites?
+            for dataset in inventory.datasets.values():
+                if dataset.size > self.max_dataset_size:
+                    continue
+
+                pattern = re.compile(rule['datasets'].replace("*","[^\s]*"))
+                if not pattern.match(dataset.name):
+                    continue
+
+                num_considered = 0
+                for site_considered in sites_considered:
+                    if dataset.find_replica(site_considered) is not None:
+                        num_considered += 1
+
+                num_others = 0
+                for site_other in sites_others:
+                    if dataset.find_replica(site_other) is not None:
+                        num_others += 1
+
+                if num_considered < rule['num_copies'] and num_others > 0 and rule['num_copies'] <= len(sites_considered):
+                    random_site = random.choice(sites_considered)
+
+                    while dataset.find_replica(random_site) is not None:
+                        random_site = random.choice(sites_considered)
+
+                    requests.append((dataset,random_site))
+
+    return requests
+

--- a/lib/dealer/plugins/enforcer.py
+++ b/lib/dealer/plugins/enforcer.py
@@ -3,6 +3,7 @@ import re
 import random
 
 from base import BaseHandler
+from dynamo.dataformat import Configuration
 
 LOG = logging.getLogger(__name__)
 
@@ -14,13 +15,14 @@ class EnforcerHandler(BaseHandler):
     def __init__(self, config):
         BaseHandler.__init__(self, 'Enforcer')
 
+        self.policy = Configuration(config.policy)
         self.max_dataset_size = config.max_dataset_size * 1.e+12
 
     def get_requests(self, inventory, policy): # override
         requests = []
 
-        for rule in config.rules:
-            # split up sites into considered ones and others                                                                                                                                               
+        for rule in self.policy.rules:
+            # split up sites into considered ones and others
             sites_considered = []
             sites_others = []
 
@@ -62,7 +64,8 @@ class EnforcerHandler(BaseHandler):
                     if dataset.find_replica(site_other) is not None:
                         num_others += 1
 
-                if num_considered < rule['num_copies'] and num_others > 0 and rule['num_copies'] <= len(sites_considered):
+                if (num_considered < rule['num_copies'] and num_others > 0 
+                    and rule['num_copies'] <= len(sites_considered)):
                     random_site = random.choice(sites_considered)
 
                     while dataset.find_replica(random_site) is not None:

--- a/lib/policy/producers/__init__.py
+++ b/lib/policy/producers/__init__.py
@@ -11,6 +11,7 @@ from mysqllock import MySQLReplicaLock
 from weblock import WebReplicaLock
 from protectedsite import ProtectedSiteTagger
 from datasetrelease import DatasetRelease
+from enforcerprotected import EnforcedProtectionTagger
 
 __all__ = [
     'CRABAccessHistory',
@@ -18,6 +19,7 @@ __all__ = [
     'MySQLReplicaLock',
     'WebReplicaLock',
     'ProtectedSiteTagger',
+    'EnforcedProtectionTagger',
     'DatasetRelease'
 ]
 

--- a/lib/policy/producers/enforcerprotected.py
+++ b/lib/policy/producers/enforcerprotected.py
@@ -1,0 +1,21 @@
+class EnforcedProtectionTagger(object):
+    """
+    Checks if the enforcer rules are respected.
+    Sets one attr:
+      enforcer_protected:    bool
+    """
+
+    produces = ['enforcer_protected']
+
+    def __init__(self, config):
+        self.sites = list(config.sites)
+
+    def load(self, inventory):
+        if len(self.sites) == 0:
+            return
+
+        for dataset in inventory.datasets.itervalues():
+            for replica in dataset.replicas:
+                if replica.site.name in self.sites:
+                    dataset.attr['on_protected_site'] = True
+                    break

--- a/lib/policy/producers/enforcerprotected.py
+++ b/lib/policy/producers/enforcerprotected.py
@@ -1,21 +1,35 @@
+import re
+
+from dynamo.dataformat import Configuration
+
 class EnforcedProtectionTagger(object):
     """
     Checks if the enforcer rules are respected.
     Sets one attr:
-      enforcer_protected:    bool
+      enforcer_protected_replicas:    set of replicas
     """
 
-    produces = ['enforcer_protected']
+    produces = ['enforcer_protected_replicas']
 
     def __init__(self, config):
-        self.sites = list(config.sites)
+        self.policy = Configuration(config.policy)
 
     def load(self, inventory):
-        if len(self.sites) == 0:
-            return
+        for rule in self.policy.rules:        
+            for dataset in inventory.datasets.itervalues():
+                pattern = re.compile(rule['datasets'].replace("*","[^\s]*"))
+                if not pattern.match(dataset.name):
+                    continue
 
-        for dataset in inventory.datasets.itervalues():
-            for replica in dataset.replicas:
-                if replica.site.name in self.sites:
-                    dataset.attr['on_protected_site'] = True
-                    break
+                replicas_in_question = []
+
+                for sitename in rule['sites']:
+                    pattern = re.compile(sitename.replace("*","[^\s]*"))
+                    for site in inventory.sites.values():
+                        if not pattern.match(site.name):
+                            continue
+                        if dataset.find_replica(site) is not None:
+                            replicas_in_question.append(dataset.find_replica(site))
+
+                if len(replicas_in_question) <= rule['copies']:
+                    dataset.attr['enforcer_protected_replicas'] = set(replicas_in_question)


### PR DESCRIPTION
The enforcer rules tell the enforcer dealer plugin how many copies of certain datasets should _at least_ be present on certain sites. At the same time, detox respects the rules and does not delete any of the replicas on the respective sites if their number is smaller than the one specified in the rule set.

See the corresponding PR in dynamo-policies.

Still missing:

- Picking an appropriate priority for the dealer plugin
- Line in Detox policy file to protect the replicas according to the dataset attribute "enforcer_protected_replicas"

